### PR TITLE
Implemented tag system for builds (selectable, editable, stored in DB)

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -19,6 +19,7 @@ export type Build = {
     runes: object | any,
     notes: string,
     votes?: number,
+    tags?: string[],
 }
 
 export function score(build: Build): number {

--- a/src/lib/server/database/queries/builds.ts
+++ b/src/lib/server/database/queries/builds.ts
@@ -18,28 +18,41 @@ export function get_builds(this: Database): Result<Build[]> {
     return Result.Ok(builds.map((build) => {
         let vote = votes.find(v => v.build_id === build.id);
         let user = usernames.find(u => u.id === build.user_id);
-        return { ...build, user_name: (user?.name ?? `user${build.user_id}`), votes: (vote?.count ?? 0) };
+        return { ...build, user_name: (user?.name ?? `user${build.user_id}`), votes: (vote?.count ?? 0), tags: Array.isArray(build.tags) ? build.tags as string[] : [] };
     }));
 }
 
 export function get_build(this: Database, id: string): Result<Build> {
-    let build = this.db.select().from(schema.builds).where(eq(schema.builds.id, id)).get();
+    const build = this.db
+        .select()
+        .from(schema.builds)
+        .where(eq(schema.builds.id, id))
+        .get();
+
     if (!build) {
         return Result.Err(new Error("build not found"));
     }
 
-    let votes = this.db.select({ count: count(schema.votes.user_id) })
+    const vote_result = this.db
+        .select({ count: count(schema.votes.user_id) })
         .from(schema.votes)
         .where(eq(schema.votes.build_id, id))
         .groupBy(schema.votes.build_id)
-        .get()!.count;
-    let user = this.db.select({ name: schema.users.name })
+        .get();
+
+    const user_result = this.db
+        .select({ name: schema.users.name })
         .from(schema.users)
         .where(eq(schema.users.id, build.user_id))
-        .get()!.name;
+        .get();
 
-    return Result.Ok({...build, user_name: user, votes});
+    const votes = vote_result?.count ?? 0;
+    const user = user_result?.name ?? `user${build.user_id}`;
+    const tags = Array.isArray(build.tags) ? build.tags as string[] : []
+
+    return Result.Ok({ ...build, user_name: user, votes, tags });
 }
+
 
 export function save_build(this: Database, data: Build): Result<string> {
     this.db.insert(schema.builds).values(data).onConflictDoUpdate({

--- a/src/lib/server/database/schema.ts
+++ b/src/lib/server/database/schema.ts
@@ -26,6 +26,7 @@ export const builds = table('builds', {
   skills: text('skills', { mode: 'json' }).default(JSON.stringify(["_", "_", "_", "_", "_", "_"])),
   runes: text('runes', { mode: 'json' }).default(JSON.stringify({ versatility: ["", "", ""], tenacity: ["", "", "", ""] })),
   notes: text('notes').notNull().default(''),
+  tags: text('tags', { mode: 'json' }).default(JSON.stringify([])),
 });
 
 export const votes = table('votes', {

--- a/src/lib/server/options/index.ts
+++ b/src/lib/server/options/index.ts
@@ -1,7 +1,9 @@
 import character_data from "./characters.json";
 import skill_data from "./skills.json";
 import rune_data from "./runes.json";
+import tag_data from "./tags.json";
 
 export const characters = character_data;
 export const skills = skill_data;
 export const runes = rune_data;
+export const tags = tag_data;

--- a/src/lib/server/options/tags.json
+++ b/src/lib/server/options/tags.json
@@ -1,0 +1,10 @@
+[
+  "Poison",
+  "Electricity",
+  "Skill-Tree Grind",
+  "Chaos",
+  "Summons",
+  "Fire",
+  "Bleed",
+  "AOE"
+]

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -113,6 +113,13 @@
                     <span class="right column">Patch: {build.patch}</span>
                 </div>
             </a>
+            	{#if build.tags && build.tags.length}
+                    <div class="tags">
+                        {#each build.tags as tag}
+                            <span class="tag">{tag}</span>
+                        {/each}
+                    </div>
+                {/if}
         </div>
     {/each}
 </div>
@@ -195,5 +202,20 @@
 
     .right {
         text-align: right;
+    }
+
+    .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 1rem;
+
+        .tag {
+            background-color: var(--primary);
+            color: rgb(0, 0, 0);
+            padding: 0.3em 0.6em;
+            border-radius: 0.3em;
+            font-size: 0.9rem;
+        }
     }
 </style>

--- a/src/routes/builds/[slug]/+page.server.ts
+++ b/src/routes/builds/[slug]/+page.server.ts
@@ -1,7 +1,7 @@
 import { redirect, type Load } from '@sveltejs/kit';
 
 import { db } from '$lib/server/database';
-import { characters, skills, runes } from '$lib/server/options';
+import { characters, skills, runes, tags } from '$lib/server/options';
 import type { Build } from '$lib';
 
 export const load: Load = async ({ params, cookies }: any) => {
@@ -29,7 +29,8 @@ export const load: Load = async ({ params, cookies }: any) => {
 				versatility: ["", "", ""],
 				tenacity: ["", "", "", ""],
 			},
-			notes: ""
+			notes: "",
+			tags: [],
 		};
 	} else {
 		build = db.get_build(params.slug).expect();
@@ -38,5 +39,5 @@ export const load: Load = async ({ params, cookies }: any) => {
 		}
 	}
 
-	return { build, editable: user.ok ? user.value.id === build.user_id : false, liked, characters, skills, runes };
+	return { build, editable: user.ok ? user.value.id === build.user_id : false, liked, characters, skills, runes, tags };
 };

--- a/src/routes/builds/[slug]/+page.svelte
+++ b/src/routes/builds/[slug]/+page.svelte
@@ -7,7 +7,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 
 	const { data } = $props();
-	const { editable, characters, skills, runes } = data;
+	const { editable, characters, skills, runes, tags } = data;
 
 	let saved_build = data.build;
 	let build = $state(data.build);
@@ -18,6 +18,15 @@
 
 	function reset() {
 		build = saved_build;
+	}
+
+	function toggleTag(tag: string) {
+		build.tags ??= []; 
+		if (build.tags.includes(tag)) {
+			build.tags = build.tags.filter((t) => t !== tag);
+		} else {
+			build.tags = [...build.tags, tag];
+		}
 	}
 
 	function save() {
@@ -178,6 +187,26 @@
 	<div style="text-align: right;">
 		Patch: {build.patch}
 	</div>
+
+	{#if editable}
+		<div class="field">
+			<!-- svelte-ignore a11y_label_has_associated_control -->
+			<label class="label">Tags</label>
+			<div class="tags are-medium">
+				{#each tags as tag}
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<span
+						role="button"
+						tabindex="0"
+						class="tag {(build.tags ?? []).includes(tag) ? 'is-selected' : ''}"
+						onclick={() => toggleTag(tag)}
+					>
+						{tag}
+					</span>
+				{/each}
+			</div>
+		</div>
+	{/if}
 </div>
 
 <br />
@@ -345,6 +374,15 @@
 	}
 	.runes .tenacity .icon {
 		transform: translateY(0.4em);
+	}
+
+	label {
+		color: white;
+	}
+
+	.tag.is-selected {
+		background-color: var(--primary);
+		color: black;
 	}
 
 	.stack {


### PR DESCRIPTION
- Implemented a tag system for builds
- Added a tags column to the builds table (stored as JSON in server/options/)

I had to change a few things in queries/build.ts to make it work on my PC.

Tags could be used later to filter builds.
Tags could eventually be associated with different colors to make them more recognizable at a glance, without needing to read them.

 